### PR TITLE
feat: uploadedByにuser.uidを保存するように変更

### DIFF
--- a/apps/functions/src/triggers/onAudioUpload.ts
+++ b/apps/functions/src/triggers/onAudioUpload.ts
@@ -41,6 +41,7 @@ export const onAudioUpload = onObjectFinalized(
   async function main(event) {
     const filePath = event.data.name;
     const contentType = event.data.contentType ?? 'application/octet-stream';
+    const uploadedBy = event.data.metadata?.uploadedBy ?? 'system';
     console.log('onAudioUpload:', { filePath, contentType });
     console.log(`Content Type: ${contentType}`);
 
@@ -84,7 +85,7 @@ export const onAudioUpload = onObjectFinalized(
           const docRef = await db.collection('transcripts').add({
             storagePath: filePath,
             text: response.text,
-            uploadedBy: 'system',
+            uploadedBy,
             createdAt: serverTimestamp, //timestamp型での時刻保存
             transcriptTotalTokens: totalTokens, // 書き起こしのトークン数
           });

--- a/apps/web/src/app/protected/upload/page.tsx
+++ b/apps/web/src/app/protected/upload/page.tsx
@@ -7,13 +7,14 @@ import { Input } from '~/components/ui/input';
 import { Skeleton } from '~/components/ui/skeleton';
 import { Button } from '~/components/ui/button';
 import { Separator } from '~/components/ui/separator';
-import { useAuthGuard } from '~/hooks/useAuthGuard';
+import { useAuth } from '~/providers/AuthProvider';
 
 const UploadPage = () => {
   const [file, setFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
   const { uploadFile } = useStorage();
+  const { currentUser } = useAuth();
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.[0]) {
@@ -26,7 +27,9 @@ const UploadPage = () => {
     setUploading(true);
     try {
       // "uploads/" フォルダにファイル名で保存
-      const url = await uploadFile(`uploads/${file.name}`, file);
+      const url = await uploadFile(`uploads/${file.name}`, file, {
+        uploadedBy: currentUser?.uid ?? '',
+      });
       setUploadedUrl(url);
       alert('アップロード完了');
     } catch (e) {

--- a/apps/web/src/providers/StorageProvider.tsx
+++ b/apps/web/src/providers/StorageProvider.tsx
@@ -5,7 +5,11 @@ import { storage } from '~/lib/firebase';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 
 type StorageContextType = {
-  uploadFile: (path: string, file: File) => Promise<string>;
+  uploadFile: (
+    path: string,
+    file: File,
+    customMetadata?: Record<string, string>,
+  ) => Promise<string>;
 };
 
 const StorageContext = createContext<StorageContextType | undefined>(undefined);
@@ -14,9 +18,16 @@ export const StorageProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   // ファイルアップロード関数
-  const uploadFile = async (path: string, file: File) => {
+  const uploadFile = async (
+    path: string,
+    file: File,
+    customMetadata?: Record<string, string>,
+  ) => {
     const fileRef = ref(storage, path);
-    await uploadBytes(fileRef, file);
+    const metadata = {
+      customMetadata: customMetadata ?? {}, // userIdをメタデータとして渡す
+    };
+    await uploadBytes(fileRef, file, metadata);
     return getDownloadURL(fileRef);
   };
 


### PR DESCRIPTION
## 概要
feat: uploadedByにuser.uidを保存するように変更
## 変更内容
<!-- 変更箇所の詳細、デザイン変更の場合スクショを貼る -->
storageProviderで、メタデータとしてcurrentUser.uidを保存するように変更
firestore保存時にuidをuploadedByとして呼び出し、それを保存するようにした
## レビューポイント
<!-- レビュー時に確認してほしいポイントがあれば箇条書きで記載する -->
