### PR TITLE
refactor: TranscriptsSearchFormを、UIと処理に分け、処理部分をuseTranscriptsSearchに切…

### DIFF
--- a/apps/web/src/app/protected/list/page.tsx
+++ b/apps/web/src/app/protected/list/page.tsx
@@ -6,9 +6,6 @@ import { useSearchTranscripts } from '~/hooks/useSearchTranscripts';
 import { useModalState } from '~/hooks/useModalState';
 import { TranscriptsSearchForm } from '~/components/TranscriptsSearchForm';
 
-console.log('Imported useSearchTranscripts:', useSearchTranscripts);
-console.log('Type:', typeof useSearchTranscripts);
-
 const ListPage = () => {
   const { audioUrls, transcripts, loading, error } = useTranscripts();
   const { filtered, searched, handleSearch } =

--- a/apps/web/src/components/TranscriptsSearchForm.tsx
+++ b/apps/web/src/components/TranscriptsSearchForm.tsx
@@ -1,63 +1,22 @@
 'use client';
 
-import { useState } from 'react';
+import { useTranscriptsSearch } from '~/hooks/useTranscriptsSearch';
 import type { Transcript } from '~/types/transcripts';
 import { Calendar } from '~/components/ui/calendar';
 import { Input } from '~/components/ui/input';
 import { Button } from '~/components/ui/button';
 
-type Props = {
+type TranscriptsSearchFormProps = {
   transcripts: Transcript[];
   onResult: (results: Transcript[]) => void;
 };
 
-export const TranscriptsSearchForm: React.FC<Props> = ({
+export const TranscriptsSearchForm: React.FC<TranscriptsSearchFormProps> = ({
   transcripts,
   onResult,
 }) => {
-  const [keyword, setKeyword] = useState('');
-  const [date, setDate] = useState<Date | undefined>(undefined);
-
-  const handleSearch = () => {
-    let results = transcripts;
-
-    // 文字起こし内容で検索
-    if (keyword) {
-      results = results.filter((t) =>
-        t.text?.toLowerCase().includes(keyword.toLowerCase()),
-      );
-    }
-
-    // 日付で検索（yyyy-mm-dd形式で部分一致）
-    if (date) {
-      const yyyy = date.getFullYear();
-      const mm = String(date.getMonth() + 1).padStart(2, '0');
-      const dd = String(date.getDate()).padStart(2, '0');
-      const selectedDate = `${yyyy}-${mm}-${dd}`;
-
-      results = results.filter((t) => {
-        if (!t.createdAt) return false;
-        let d: Date;
-        // Timestamp型（toDateがある）ならDate型に変換
-        if (
-          typeof t.createdAt === 'object' &&
-          t.createdAt !== null &&
-          typeof (t.createdAt as { toDate?: unknown }).toDate === 'function'
-        ) {
-          d = (t.createdAt as { toDate: () => Date }).toDate();
-        } else {
-          d = new Date(t.createdAt as string | Date);
-        }
-        // 日付をyyyy-mm-dd形式に変換
-        const yyyy = d.getFullYear();
-        const mm = String(d.getMonth() + 1).padStart(2, '0');
-        const dd = String(d.getDate()).padStart(2, '0');
-        const targetDate = `${yyyy}-${mm}-${dd}`;
-        return targetDate === selectedDate;
-      });
-    }
-    onResult(results);
-  };
+  const { keyword, setKeyword, date, setDate, handleSearch } =
+    useTranscriptsSearch(transcripts, onResult);
 
   return (
     <div className="">
@@ -68,7 +27,6 @@ export const TranscriptsSearchForm: React.FC<Props> = ({
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
         />
-
         <Calendar mode="single" selected={date} onSelect={setDate} />
         <Button
           type="button"

--- a/apps/web/src/hooks/useTranscriptsSearch.tsx
+++ b/apps/web/src/hooks/useTranscriptsSearch.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { useState } from 'react';
+import type { Transcript } from '~/types/transcripts';
+
+export function useTranscriptsSearch(
+  transcripts: Transcript[],
+  onResult: (results: Transcript[]) => void,
+) {
+  const [keyword, setKeyword] = useState('');
+  const [date, setDate] = useState<Date | undefined>(undefined);
+
+  const handleSearch = () => {
+    let results = transcripts;
+
+    // 文字起こし内容で検索
+    if (keyword) {
+      results = results.filter((t) =>
+        t.text?.toLowerCase().includes(keyword.toLowerCase()),
+      );
+    }
+
+    // 日付で検索（yyyy-mm-dd形式で部分一致）
+    if (date) {
+      const yyyy = date.getFullYear();
+      const mm = String(date.getMonth() + 1).padStart(2, '0');
+      const dd = String(date.getDate()).padStart(2, '0');
+      const selectedDate = `${yyyy}-${mm}-${dd}`;
+
+      results = results.filter((t) => {
+        if (!t.createdAt) return false;
+        let d: Date;
+        // Timestamp型（toDateがある）ならDate型に変換
+        if (
+          typeof t.createdAt === 'object' &&
+          t.createdAt !== null &&
+          typeof (t.createdAt as { toDate?: unknown }).toDate === 'function'
+        ) {
+          d = (t.createdAt as { toDate: () => Date }).toDate();
+        } else {
+          d = new Date(t.createdAt as string | Date);
+        }
+        // 日付をyyyy-mm-dd形式に変換
+        const yyyy = d.getFullYear();
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        const dd = String(d.getDate()).padStart(2, '0');
+        const targetDate = `${yyyy}-${mm}-${dd}`;
+        return targetDate === selectedDate;
+      });
+    }
+    onResult(results);
+  };
+
+  return {
+    keyword,
+    setKeyword,
+    date,
+    setDate,
+    handleSearch,
+  };
+}


### PR DESCRIPTION
## 概要
efactor: TranscriptsSearchFormを、UIと処理に分け、処理部分をuseTranscriptsSearchに切りだした
## 変更内容
<!-- 変更箇所の詳細、デザイン変更の場合スクショを貼る -->
hooksにuseTranscriptsSearchのカスタムフックを作成し検索処理を担当させ、TranscriptsSearchFormのUIと処理を分けた

## レビューポイント
<!-- レビュー時に確認してほしいポイントがあれば箇条書きで記載する -->
