### PR TITLE
refactor: res.okでのif分岐からtry catchを使ったものに変更

### DIFF
--- a/apps/functions/src/lib/Slack/notifySlack.ts
+++ b/apps/functions/src/lib/Slack/notifySlack.ts
@@ -18,14 +18,13 @@ export async function notifySlack(summary: string) {
   const payload = {
     text,
   };
-  const res = await fetch(slackWebhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) {
-    console.error('Slack通知に失敗しました:', await res.text());
-  } else {
-    console.log('Slack通知に成功しました');
+  try {
+    await fetch(slackWebhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    console.error('Slack通知中に失敗しました:', error);
   }
 }

--- a/apps/functions/src/triggers/scheduledTask.ts
+++ b/apps/functions/src/triggers/scheduledTask.ts
@@ -1,6 +1,6 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { summarizeYesterdayTranscripts } from '../lib/gemini/summarize';
-import { notifySlack } from '../lib/Slack/notifySlack';
+import { notifySlack } from '../lib/slack/notifySlack';
 
 export const dailySummary = onSchedule(
   {


### PR DESCRIPTION
## 概要
refactor: res.okでのif分岐からtry catchを使ったものに変更
## 変更内容
<!-- 変更箇所の詳細、デザイン変更の場合スクショを貼る -->
res.okでエラーハンドリングしていたものからtry catchを使うようにした
## レビューポイント
<!-- レビュー時に確認してほしいポイントがあれば箇条書きで記載する -->
