### PR TITLE
refactor: summarize.tsの責務を分割した

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@google/genai": "^1.6.0",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.13",
     "express": "^4.21.2",
     "express-promise-router": "^4.1.1",
     "express-validator": "^7.2.1",

--- a/apps/functions/src/infrastructure/firestore/summary.ts
+++ b/apps/functions/src/infrastructure/firestore/summary.ts
@@ -1,0 +1,48 @@
+import { db } from '~/lib/firebase';
+import { summarizeText } from '~/lib/gemini/summarize';
+import dayjs from 'dayjs';
+
+export async function summarizeYesterdayTranscripts() {
+  const start = dayjs().subtract(1, 'day').startOf('day').toDate();
+  const end = dayjs().subtract(1, 'day').endOf('day').toDate();
+
+  console.log(`書き起こし期間: ${start} から ${end}`);
+
+  const snapshot = await db
+    .collection('transcripts')
+    .where('createdAt', '>=', start)
+    .where('createdAt', '<=', end)
+    .get();
+
+  if (snapshot.empty) {
+    console.log('昨日分のtranscriptsはありません');
+    return null;
+  }
+
+  const summaries: string[] = [];
+  let count = 1;
+  for (const doc of snapshot.docs) {
+    const text = doc.data().text;
+    const transcriptTotalTokens = doc.data().transcriptTotalTokens ?? 0;
+    if (!text) continue;
+
+    try {
+      const { summary, totalTokens: summaryTokens } = await summarizeText(text);
+      const totalTokens = summaryTokens + transcriptTotalTokens;
+      await db.collection('transcripts').doc(doc.id).update({
+        summary,
+        summaryTotalTokens: summaryTokens,
+        totalTokens,
+      });
+
+      summaries.push(
+        `書き起こし${count}\nFireStoreドキュメントID${doc.id}\n消費トークン総数${totalTokens}\n${summary}\n`,
+      );
+      count++;
+    } catch (error) {
+      console.error(`要約生成エラー (ドキュメントID: ${doc.id}):`, error);
+    }
+  }
+
+  return summaries.join('');
+}

--- a/apps/functions/src/lib/gemini/summarize.ts
+++ b/apps/functions/src/lib/gemini/summarize.ts
@@ -1,99 +1,36 @@
-import { db } from '~/lib/firebase';
 import { GoogleGenAI } from '@google/genai';
 
 const ai = new GoogleGenAI({
   apiKey: process.env.DEV_GEMINI_API_KEY,
 });
 
-export async function summarizeYesterdayTranscripts() {
-  // 現在日時
-  const now = new Date();
-  // 昨日の0時
-  const start = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate() - 1,
-    0,
-    0,
-    0,
-    0,
-  );
-  // 昨日の23:59:59
-  const end = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate() - 1,
-    23,
-    59,
-    59,
-    999,
-  );
-
-  const snapshot = await db
-    .collection('transcripts')
-    .where('createdAt', '>=', start)
-    .where('createdAt', '<=', end)
-    .get();
-
-  if (snapshot.empty) {
-    console.log('昨日分のtranscriptsはありません');
-    return null;
-  }
-
-  // 各ドキュメントごとに要約し、summaryフィールドを保存
-  const summaries: string[] = [];
-  let count = 1;
-  for (const doc of snapshot.docs) {
-    const text = doc.data().text;
-    const transcriptTotalTokens = doc.data().transcriptTotalTokens ?? 0;
-    if (!text) continue;
-
-    try {
-      const response = await ai.models.generateContent({
-        model: 'gemini-1.5-flash',
-        contents: [
+export async function summarizeText(
+  text: string,
+): Promise<{ summary: string; totalTokens: number }> {
+  const response = await ai.models.generateContent({
+    model: 'gemini-1.5-flash',
+    contents: [
+      {
+        role: 'user',
+        parts: [
           {
-            role: 'user',
-            parts: [
-              {
-                text: `以下の会議書き起こしを要約してください（日本語）:\n${text}`,
-              },
-            ],
+            text: `以下の会議書き起こしを要約してください（日本語）:\n${text}`,
           },
         ],
-        config: {
-          systemInstruction:
-            'エンジニアが話した文章の書き起こしです。日本語で簡潔にまとめてください。',
-        },
-      });
-      // トークン数のログ出力
-      let summariesTotalTokens = 0;
-      if (response.usageMetadata) {
-        const promptTokens = response.usageMetadata.promptTokenCount ?? 0;
-        const responseTokens = response.usageMetadata.candidatesTokenCount ?? 0;
-        summariesTotalTokens = promptTokens + responseTokens;
-        console.log(
-          `Prompt tokens: ${promptTokens}, ` +
-            `Response tokens: ${responseTokens}, ` +
-            `Total tokens: ${summariesTotalTokens}`,
-        );
-      }
-      const totalTokens = summariesTotalTokens + transcriptTotalTokens;
-      const summary = response.text ?? '';
-      await db.collection('transcripts').doc(doc.id).update({
-        summary,
-        summaryTotalTokens: summariesTotalTokens, // 要約生成時のトークン数
-        totalTokens, // 書き起こし＋要約の合計トークン数
-      });
+      },
+    ],
+    config: {
+      systemInstruction:
+        'エンジニアが話した文章の書き起こしです。日本語で簡潔にまとめてください。',
+    },
+  });
 
-      summaries.push(
-        `書き起こし${count}\nFireStoreドキュメントID${doc.id}\n消費トークン総数${totalTokens}\n${summary}\n`,
-      );
-      count++;
-    } catch (error) {
-      console.error(`要約生成エラー (ドキュメントID: ${doc.id}):`, error);
-    }
-  }
+  const promptTokens = response.usageMetadata?.promptTokenCount ?? 0;
+  const responseTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+  const totalTokens = promptTokens + responseTokens;
 
-  return summaries.join('');
+  return {
+    summary: response.text ?? '',
+    totalTokens,
+  };
 }

--- a/apps/functions/src/triggers/scheduledTask.ts
+++ b/apps/functions/src/triggers/scheduledTask.ts
@@ -1,5 +1,5 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
-import { summarizeYesterdayTranscripts } from '~/lib/gemini/summarize';
+import { summarizeYesterdayTranscripts } from '~/infrastructure/firestore/summary';
 import { notifySlack } from '~/lib/slack/notifySlack';
 import { defineString } from 'firebase-functions/params';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -144,7 +147,7 @@ importers:
         version: 1.2.3(@types/react@19.0.12)(react@19.1.0)
       '@sentry/nextjs':
         specifier: ^9.10.1
-        version: 9.31.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react@19.1.0)(webpack@5.99.9)
+        version: 9.31.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.2.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react@19.1.0)(webpack@5.99.9)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -171,7 +174,7 @@ importers:
         version: 0.523.0(react@19.1.0)
       next:
         specifier: 15.2.4
-        version: 15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2)
+        version: 15.2.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -8618,7 +8621,7 @@ snapshots:
 
   '@sentry/core@9.31.0': {}
 
-  '@sentry/nextjs@9.31.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react@19.1.0)(webpack@5.99.9)':
+  '@sentry/nextjs@9.31.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.2.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react@19.1.0)(webpack@5.99.9)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.34.0
@@ -8631,7 +8634,7 @@ snapshots:
       '@sentry/vercel-edge': 9.31.0
       '@sentry/webpack-plugin': 3.5.0(webpack@5.99.9)
       chalk: 3.0.0
-      next: 15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2)
+      next: 15.2.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2)
       resolve: 1.22.8
       rollup: 4.35.0
       stacktrace-parser: 0.1.11
@@ -11121,7 +11124,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2):
+  next@15.2.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2):
     dependencies:
       '@next/env': 15.2.4
       '@swc/counter': 0.1.3
@@ -11131,7 +11134,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.4)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.2.4
       '@next/swc-darwin-x64': 15.2.4
@@ -11993,10 +11996,12 @@ snapshots:
   stubs@3.0.0:
     optional: true
 
-  styled-jsx@5.1.6(react@19.1.0):
+  styled-jsx@5.1.6(@babel/core@7.27.4)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
+    optionalDependencies:
+      '@babel/core': 7.27.4
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
## 概要
refactor: summarize.tsの責務を分割した,日付操作をdayjsに変更した
## 変更内容
<!-- 変更箇所の詳細、デザイン変更の場合スクショを貼る -->
summarize.tsのfirestore呼び出しとgeminiAPI呼び出しの機能を分けた
日付操作をdayjsに変更した
## レビューポイント
<!-- レビュー時に確認してほしいポイントがあれば箇条書きで記載する -->
