### PR TITLE
refactor: リストページの並び順を、createdAtの降順に変更。

### DIFF
--- a/apps/web/src/hooks/useFetchTranscripts.tsx
+++ b/apps/web/src/hooks/useFetchTranscripts.tsx
@@ -15,7 +15,7 @@ export const useFetchTranscripts = () => {
       try {
         setLoading(true);
         setError(null);
-        const docs = await getAllDocuments('transcripts');
+        const docs = await getAllDocuments('transcripts', 'createdAt', 'desc');
         const data = docs.map((doc) => ({
           id: doc.id,
           ...doc.data(),

--- a/apps/web/src/infrastructure/firestore/DbProvider.tsx
+++ b/apps/web/src/infrastructure/firestore/DbProvider.tsx
@@ -8,7 +8,10 @@ import {
   getDocs,
   doc,
   setDoc,
+  query,
+  orderBy,
 } from 'firebase/firestore';
+import type { CollectionReference, Query } from 'firebase/firestore';
 import type { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
 
 type FirestoreContextType = {
@@ -16,6 +19,8 @@ type FirestoreContextType = {
   getDocument: (col: string, id: string) => Promise<DocumentData | undefined>;
   getAllDocuments: (
     col: string,
+    orderKey: string,
+    orderDirection: 'asc' | 'desc',
   ) => Promise<QueryDocumentSnapshot<DocumentData>[]>;
   setDocument: (
     col: string,
@@ -44,8 +49,18 @@ export const DbProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   // コレクション全件取得
-  const getAllDocuments = async (col: string) => {
-    const snap = await getDocs(collection(db, col));
+  const getAllDocuments = async (
+    col: string,
+    orderKey: string,
+    orderDirection: 'asc' | 'desc' = 'desc',
+  ) => {
+    let q: Query | CollectionReference;
+    if (orderKey) {
+      q = query(collection(db, col), orderBy(orderKey, orderDirection));
+    } else {
+      q = collection(db, col);
+    }
+    const snap = await getDocs(q);
     return snap.docs;
   };
 


### PR DESCRIPTION
## 概要
refactor: リストページの並び順を、createdAtの降順に変更。
## 変更内容
<!-- 変更箇所の詳細、デザイン変更の場合スクショを貼る -->
DBProviderでドキュメント取得にorderByを設定した。リストページでのドキュメント取得をcreatedAtの降順に変更することで、一覧を時間順で表示できるようにした。
## レビューポイント
<!-- レビュー時に確認してほしいポイントがあれば箇条書きで記載する -->
